### PR TITLE
fix label2Num get by key and move to spark 2.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.iml
+.idea
+.directory
+target

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
   <name>${project.artifactId}</name>
   <groupId>sramirez</groupId>
   <artifactId>spark-RELIEFFC-fselection</artifactId>
@@ -16,12 +16,12 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-mllib_2.11</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/src/main/scala/org/apache/spark/ml/feature/ReliefFRSelector.scala
+++ b/src/main/scala/org/apache/spark/ml/feature/ReliefFRSelector.scala
@@ -416,7 +416,7 @@ final class ReliefFRSelector @Since("1.6.0") (@Since("1.6.0") override val uid: 
                     val distanceThreshold = if(isCont) 6 * (1 - (lowerDistanceTh + rnumber * lowerDistanceTh)) else 0.0f
                     neighbors.map{ lidx =>
                       val Row(ninput: Vector, nlabel: Double) = localExamples(lidx)
-                      val labelIndex = label2Num.get(nlabel.toFloat).get
+                      val labelIndex = label2Num(nlabel)
                       val mod = if(nlabel == qlabel) label2Num.size * MOD.sameClass else label2Num.size * MOD.otherClass
                       classCounter(labelIndex + mod) += 1
                             


### PR DESCRIPTION
Hi, I tried to use your package but I encountered problems with Option.None when labels2Num is accessed by a key.
The problem was that I was using labels represented in Double and so is your dictionary's type, but you used "toFloat" conversion which caused the error. When "toFloat" is removed, it is working as intended.
Here I propose this fix as a pull request.
I also changed spark from 2.2.0 to 2.2.1 which is newer but still from the same 2.2.x family and added a small gitignore file.